### PR TITLE
Fix mismatching embed color

### DIFF
--- a/ext/utils/api.py
+++ b/ext/utils/api.py
@@ -125,7 +125,7 @@ class RTFMManager:
 
         matches = process.extract(obj, self._rtfm_cache.keys(), scorer=fuzz.QRatio, limit=10)
 
-        e = hikari.Embed(colour=0x39393F)
+        e = hikari.Embed(colour=0x2F3136)
         if len(matches) == 0:
             return "Could not find anything. Sorry."
 


### PR DESCRIPTION
The original color was the wrong embed color to match Discord's dark mode embed. This has been updated to the correct color.